### PR TITLE
36 deploy project to aet cluster

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -1,0 +1,39 @@
+name: Build and Publish Docker Images
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    services:
+      docker:
+        image: docker:19.03.12
+        options: >-
+          --privileged
+          --network=host
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker images
+        run: |
+          docker-compose build
+          docker-compose push
+
+      - name: Clean up
+        run: docker-compose down

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy Helm Chart to Rancher
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Kubeconfig
+        run: |
+          mkdir -p $HOME/.kube
+          echo "${{ secrets.KUBECONFIG_DATA }}" | base64 -d > $HOME/.kube/config
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Deploy Helm Chart
+        run: |
+          helm upgrade --install wiki ./helm/wiki --namespace wiki --create-namespace
+
+      - name: Verify Deployment
+        run: |
+          kubectl get pods -n wiki

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,11 +29,9 @@ services:
       - app_network
     depends_on:
       - database
-    volumes:
-      - /proc/meminfo:/proc/meminfo:ro
-      - /proc/stat:/proc/stat:ro
 
   gpt4all:
+    image: ghcr.io/team-503-brain-not-available/gpt4all:latest
     container_name: "gpt4all"
     build:
       context: ./genai/gpt4all
@@ -44,6 +42,7 @@ services:
       - app_network
 
   weaviate:
+    image: ghcr.io/team-503-brain-not-available/weaviate:latest
     container_name: "weaviate"
     build:
       context: ./genai/weaviate
@@ -55,6 +54,7 @@ services:
       - app_network
 
   prometheus:
+    image: ghcr.io/team-503-brain-not-available/prometheus:latest
     container_name: "prometheus"
     build:
       context: ./monitoring/prometheus
@@ -67,6 +67,7 @@ services:
       - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
 
   grafana:
+    image: ghcr.io/team-503-brain-not-available/grafana:latest
     container_name: "grafana"
     build:
       context: ./monitoring/grafana

--- a/helm/wiki/Chart.yaml
+++ b/helm/wiki/Chart.yaml
@@ -1,0 +1,9 @@
+name: wiki
+version: 0.1.0
+description: A Helm chart for deploying a suite of services including MariaDB, phpMyAdmin, Grafana, Prometheus, cAdvisor, Node Exporter, gpt4all, and Weaviate.
+keywords:
+  - helm
+  - kubernetes
+  - monitoring
+  - database
+  - ai

--- a/helm/wiki/README.md
+++ b/helm/wiki/README.md
@@ -1,0 +1,49 @@
+# Helm Chart for Wiki
+
+This Helm chart deploys a set of services for the Wiki project, including a database, monitoring tools, and a user interface for managing and visualizing data.
+
+## Prerequisites
+
+- Kubernetes cluster
+- Helm 3.x installed
+
+## Installation
+
+To install the chart, use the following command:
+
+```bash
+helm install <release-name> ./wiki
+```
+
+Replace `<release-name>` with a name for your release.
+
+## Configuration
+
+You can customize the deployment by modifying the `values.yaml` file. This file contains default configuration values for the chart.
+
+## Services Included
+
+- **Database**: MariaDB for data storage.
+- **phpMyAdmin**: Web interface for managing the database.
+- **Grafana**: Visualization tool for monitoring data.
+- **Prometheus**: Monitoring and alerting toolkit.
+- **cAdvisor**: Resource usage and performance characteristics of running containers.
+- **Node Exporter**: Exposes hardware and OS metrics.
+- **gpt4all**: AI model service.
+- **Weaviate**: Vector search engine.
+
+## Accessing the Services
+
+After installation, you can access the services using the following URLs:
+
+- phpMyAdmin: `http://<your-k8s-cluster-ip>:8088`
+- Grafana: `http://<your-k8s-cluster-ip>:3000`
+- Prometheus: `http://<your-k8s-cluster-ip>:9090`
+- cAdvisor: `http://<your-k8s-cluster-ip>:8081`
+- Node Exporter: `http://<your-k8s-cluster-ip>:9100`
+- gpt4all: `http://<your-k8s-cluster-ip>:5000`
+- Weaviate: `http://<your-k8s-cluster-ip>:8080`
+
+## License
+
+This project is licensed under the MIT License. See the LICENSE file for details.

--- a/helm/wiki/templates/_helpers.tpl
+++ b/helm/wiki/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/*
+Helper templates for the Helm chart
+*/}}
+
+{{- define "wiki.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "wiki.chart" -}}
+{{ .Chart.Name }}-{{ .Chart.Version }}
+{{- end -}}
+
+{{- define "wiki.fullname" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "wiki.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- .Release.Name }}-{{ .Chart.Name }}-sa
+{{- else -}}
+{{- .Values.serviceAccount.name | quote }}
+{{- end -}}
+{{- end -}}
+
+{{- define "wiki.labels" -}}
+app: {{ .Chart.Name }}
+release: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "wiki.selectorLabels" -}}
+{{- include "wiki.labels" . | nindent 4 }}
+{{- end -}}

--- a/helm/wiki/templates/cadvisor-deployment.yaml
+++ b/helm/wiki/templates/cadvisor-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: cadvisor
-          image: gcr.io/cadvisor/cadvisor:latest
+          image: {{ .Values.cadvisor.image.repository }}:{{ .Values.cadvisor.image.tag }}
           ports:
             - containerPort: 8080
           volumeMounts:

--- a/helm/wiki/templates/cadvisor-deployment.yaml
+++ b/helm/wiki/templates/cadvisor-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cadvisor
+  labels:
+    app: cadvisor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cadvisor
+  template:
+    metadata:
+      labels:
+        app: cadvisor
+    spec:
+      containers:
+        - name: cadvisor
+          image: gcr.io/cadvisor/cadvisor:latest
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: rootfs
+              mountPath: /rootfs
+              readOnly: true
+            - name: varrun
+              mountPath: /var/run
+              readOnly: true
+            - name: sys
+              mountPath: /sys
+              readOnly: true
+            - name: dockersock
+              mountPath: /var/lib/docker
+              readOnly: true
+      volumes:
+        - name: rootfs
+          hostPath:
+            path: /
+        - name: varrun
+          hostPath:
+            path: /var/run
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: dockersock
+          hostPath:
+            path: /var/lib/docker

--- a/helm/wiki/templates/cadvisor-deployment.yaml
+++ b/helm/wiki/templates/cadvisor-deployment.yaml
@@ -25,7 +25,6 @@ spec:
               readOnly: true
             - name: varrun
               mountPath: /var/run
-              readOnly: true
             - name: sys
               mountPath: /sys
               readOnly: true

--- a/helm/wiki/templates/cadvisor-service.yaml
+++ b/helm/wiki/templates/cadvisor-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wiki.fullname" . }}-cadvisor
+  labels:
+    app: {{ include "wiki.name" . }}
+    chart: {{ include "wiki.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ include "wiki.name" . }}
+    component: cadvisor

--- a/helm/wiki/templates/database-deployment.yaml
+++ b/helm/wiki/templates/database-deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "wiki.fullname" . }}-database
+  labels:
+    app: {{ include "wiki.name" . }}
+    component: database
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "wiki.name" . }}
+      component: database
+  template:
+    metadata:
+      labels:
+        app: {{ include "wiki.name" . }}
+        component: database
+    spec:
+      containers:
+        - name: database
+          image: mariadb:10.7
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: {{ .Values.database.rootPassword }}
+          volumeMounts:
+            - name: mariadb-data
+              mountPath: /var/lib/mysql
+      volumes:
+        - name: mariadb-data
+          persistentVolumeClaim:
+            claimName: {{ include "wiki.fullname" . }}-mariadb-data
+      restartPolicy: Always

--- a/helm/wiki/templates/database-deployment.yaml
+++ b/helm/wiki/templates/database-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: database
-          image: mariadb:10.7
+          image: {{ .Values.gpt4all.database.repository }}:{{ .Values.database.image.tag }}
           env:
             - name: MYSQL_ROOT_PASSWORD
               value: {{ .Values.database.rootPassword }}

--- a/helm/wiki/templates/database-deployment.yaml
+++ b/helm/wiki/templates/database-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: database
-          image: {{ .Values.gpt4all.database.repository }}:{{ .Values.database.image.tag }}
+          image: {{ .Values.database.image.repository }}:{{ .Values.database.image.tag }}
           env:
             - name: MYSQL_ROOT_PASSWORD
               value: {{ .Values.database.rootPassword }}

--- a/helm/wiki/templates/database-pvc.yaml
+++ b/helm/wiki/templates/database-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "wiki.fullname" . }}-mariadb-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/helm/wiki/templates/database-service.yaml
+++ b/helm/wiki/templates/database-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wiki.fullname" . }}-database
+  labels:
+    {{- include "wiki.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3306
+      targetPort: 3306
+      protocol: TCP
+      name: mysql
+  selector:
+    app: {{ include "wiki.name" . }}
+    component: database

--- a/helm/wiki/templates/gpt4all-deployment.yaml
+++ b/helm/wiki/templates/gpt4all-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gpt4all
+  labels:
+    app: gpt4all
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gpt4all
+  template:
+    metadata:
+      labels:
+        app: gpt4all
+    spec:
+      containers:
+        - name: gpt4all
+          image: {{ .Values.gpt4all.image.repository }}:{{ .Values.gpt4all.image.tag }}
+          ports:
+            - containerPort: 5000

--- a/helm/wiki/templates/gpt4all-service.yaml
+++ b/helm/wiki/templates/gpt4all-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wiki.fullname" . }}-gpt4all
+  labels:
+    app: {{ include "wiki.name" . }}
+    chart: {{ include "wiki.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5000
+      targetPort: 5000
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ include "wiki.name" . }}
+    component: gpt4all

--- a/helm/wiki/templates/grafana-deployment.yaml
+++ b/helm/wiki/templates/grafana-deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "wiki.fullname" . }}-grafana
+  labels:
+    app: {{ include "wiki.name" . }}
+    chart: {{ include "wiki.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "wiki.name" . }}
+      component: grafana
+  template:
+    metadata:
+      labels:
+        app: {{ include "wiki.name" . }}
+        component: grafana
+    spec:
+      containers:
+        - name: grafana
+          image: {{ .Values.grafana.image.repository }}:{{ .Values.grafana.image.tag }}
+          ports:
+            - containerPort: 3000
+          env:
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              value: {{ .Values.grafana.adminPassword }}
+            - name: GF_USERS_ALLOW_SIGN_UP
+              value: "false"
+            - name: GF_AUTH_ANONYMOUS_ENABLED
+              value: "true"
+            - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+              value: "Viewer"
+            - name: GF_AUTH_ANONYMOUS_ORG_ID
+              value: "1"
+            - name: GF_SERVER_ROOT_URL
+              value: "%(protocol)s://%(domain)s:%(http_port)s/"
+            - name: GF_SERVER_SERVE_FROM_SUB_PATH
+              value: "true"
+          volumeMounts:
+            - name: grafana-storage
+              mountPath: /var/lib/grafana
+      volumes:
+        - name: grafana-storage
+          persistentVolumeClaim:
+            claimName: grafana-storage-claim

--- a/helm/wiki/templates/grafana-pvc.yaml
+++ b/helm/wiki/templates/grafana-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana-storage-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/helm/wiki/templates/grafana-service.yaml
+++ b/helm/wiki/templates/grafana-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wiki.fullname" . }}-grafana
+  labels:
+    {{- include "wiki.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3000
+      targetPort: 3000
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ include "wiki.name" . }}
+    component: grafana

--- a/helm/wiki/templates/ingress.yaml
+++ b/helm/wiki/templates/ingress.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "{{ .Release.Name }}-ingress"
+  {{- $annotations := .Values.ingress.annotations | default dict }}
+  {{- if $annotations }}
+  annotations:
+    {{- toYaml $annotations | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    - hosts:
+        - "{{ .Values.ingress.host }}"
+      secretName: "{{ .Release.Name }}-tls"
+  {{- end }}
+  rules:
+    - host: "{{ .Values.ingress.host }}"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}-service
+                port:
+                  number: 80
+          - path: /grafana
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}-grafana-service
+                port:
+                  number: 3000
+          - path: /phpmyadmin
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}-phpmyadmin-service
+                port:
+                  number: 80
+          - path: /prometheus
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}-prometheus-service
+                port:
+                  number: 9090
+          - path: /weaviate
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}-weaviate-service
+                port:
+                  number: 8080
+          - path: /gpt4all
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}-gpt4all-service
+                port:
+                  number: 5000
+          - path: /cadvisor
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}-cadvisor-service
+                port:
+                  number: 8080
+{{- end }}

--- a/helm/wiki/templates/node-exporter-deployment.yaml
+++ b/helm/wiki/templates/node-exporter-deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "wiki.fullname" . }}-node-exporter
+  labels:
+    app: {{ include "wiki.name" . }}-node-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "wiki.name" . }}-node-exporter
+  template:
+    metadata:
+      labels:
+        app: {{ include "wiki.name" . }}-node-exporter
+    spec:
+      containers:
+        - name: node-exporter
+          image: {{ .Values.nodeExporter.image }}
+          ports:
+            - containerPort: 9100
+          volumeMounts:
+            - name: proc
+              mountPath: /host/proc
+              readOnly: true
+            - name: sys
+              mountPath: /host/sys
+              readOnly: true
+            - name: rootfs
+              mountPath: /rootfs
+              readOnly: true
+      volumes:
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: rootfs
+          hostPath:
+            path: /

--- a/helm/wiki/templates/node-exporter-deployment.yaml
+++ b/helm/wiki/templates/node-exporter-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: node-exporter
-          image: {{ .Values.nodeExporter.image }}
+          image: {{ .Values.nodeExporter.image.repository }}:{{ .Values.nodeExporter.image.tag }}
           ports:
             - containerPort: 9100
           volumeMounts:

--- a/helm/wiki/templates/node-exporter-service.yaml
+++ b/helm/wiki/templates/node-exporter-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: node-exporter
+  labels:
+    app: node-exporter
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9100
+      targetPort: 9100
+      protocol: TCP
+  selector:
+    app: node-exporter

--- a/helm/wiki/templates/phpmyadmin-deployment.yaml
+++ b/helm/wiki/templates/phpmyadmin-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "wiki.fullname" . }}-phpmyadmin
+  labels:
+    app: {{ include "wiki.name" . }}
+    component: phpmyadmin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "wiki.name" . }}
+      component: phpmyadmin
+  template:
+    metadata:
+      labels:
+        app: {{ include "wiki.name" . }}
+        component: phpmyadmin
+    spec:
+      containers:
+        - name: phpmyadmin
+          image: phpmyadmin/phpmyadmin:latest
+          ports:
+            - containerPort: 80
+          env:
+            - name: PMA_HOST
+              value: {{ .Values.phpmyadmin.host }}
+            - name: MYSQL_ROOT_PASSWORD
+              value: {{ .Values.database.rootPassword }}
+            - name: UPLOAD_LIMIT
+              value: {{ .Values.phpmyadmin.uploadLimit }}
+          volumeMounts:
+            - name: proc-meminfo
+              mountPath: /proc/meminfo
+              subPath: meminfo
+              readOnly: true
+            - name: proc-stat
+              mountPath: /proc/stat
+              subPath: stat
+              readOnly: true
+      volumes:
+        - name: proc-meminfo
+          hostPath:
+            path: /proc/meminfo
+        - name: proc-stat
+          hostPath:
+            path: /proc/stat

--- a/helm/wiki/templates/phpmyadmin-deployment.yaml
+++ b/helm/wiki/templates/phpmyadmin-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: phpmyadmin
-          image: phpmyadmin/phpmyadmin:latest
+          image: {{ .Values.gpt4all.image.repository }}:{{ .Values.gpt4all.image.tag }}
           ports:
             - containerPort: 80
           env:

--- a/helm/wiki/templates/phpmyadmin-service.yaml
+++ b/helm/wiki/templates/phpmyadmin-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wiki.fullname" . }}-phpmyadmin
+  labels:
+    {{- include "wiki.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ include "wiki.name" . }}
+    component: phpmyadmin

--- a/helm/wiki/templates/prometheus-deployment.yaml
+++ b/helm/wiki/templates/prometheus-deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  labels:
+    app: prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+        - name: prometheus
+          image: prom/prometheus:latest
+          ports:
+            - containerPort: 9090
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/prometheus
+          args:
+            - "--config.file=/etc/prometheus/prometheus.yml"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: prometheus-config
+      restartPolicy: Always

--- a/helm/wiki/templates/prometheus-deployment.yaml
+++ b/helm/wiki/templates/prometheus-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: prometheus
-          image: prom/prometheus:latest
+          image: {{ .Values.gpt4all.image.repository }}:{{ .Values.gpt4all.image.tag }}
           ports:
             - containerPort: 9090
           volumeMounts:

--- a/helm/wiki/templates/prometheus-service.yaml
+++ b/helm/wiki/templates/prometheus-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  labels:
+    app: prometheus
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9090
+      targetPort: 9090
+      protocol: TCP
+  selector:
+    app: prometheus

--- a/helm/wiki/templates/weaviate-deployment.yaml
+++ b/helm/wiki/templates/weaviate-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "wiki.fullname" . }}-weaviate
+  labels:
+    app: {{ include "wiki.name" . }}-weaviate
+spec:
+  replicas: {{ .Values.weaviate.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "wiki.name" . }}-weaviate
+  template:
+    metadata:
+      labels:
+        app: {{ include "wiki.name" . }}-weaviate
+    spec:
+      containers:
+        - name: weaviate
+          image: {{ .Values.weaviate.image.repository }}:{{ .Values.weaviate.image.tag }}
+          ports:
+            - containerPort: 8080
+          env:
+            - name: WEAVIATE_HOST
+              value: "0.0.0.0"
+            - name: WEAVIATE_PORT
+              value: "8080"
+            - name: WEAVIATE_AUTHENTICATION
+              value: "false"
+          resources:
+            {{- toYaml .Values.weaviate.resources | nindent 12 }}

--- a/helm/wiki/templates/weaviate-service.yaml
+++ b/helm/wiki/templates/weaviate-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: weaviate
+  labels:
+    app: weaviate
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 8080
+      protocol: TCP
+      name: http
+    - port: 50051
+      targetPort: 50051
+      protocol: TCP
+      name: grpc
+  selector:
+    app: weaviate

--- a/helm/wiki/values.yaml
+++ b/helm/wiki/values.yaml
@@ -27,22 +27,22 @@ phpmyadmin:
 
 gpt4all:
   image:
-    repository: gpt4all
+    repository: ghcr.io/team-503-brain-not-available/gpt4all
     tag: latest
 
 weaviate:
   image:
-    repository: weaviate
+    repository: ghcr.io/team-503-brain-not-available/weaviate
     tag: latest
 
 prometheus:
   image:
-    repository: prometheus
+    repository: ghcr.io/team-503-brain-not-available/prometheus
     tag: latest
 
 grafana:
   image:
-    repository: grafana
+    repository: ghcr.io/team-503-brain-not-available/grafana
     tag: latest
   adminPassword: admin
   allowSignUp: false

--- a/helm/wiki/values.yaml
+++ b/helm/wiki/values.yaml
@@ -1,0 +1,75 @@
+# Default configuration values for the Helm chart
+
+replicaCount: 1
+
+database:
+  image:
+    repository: mariadb
+    tag: "10.7"
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 3306
+  rootPassword: rand528PASS-wd
+  persistence:
+    enabled: true
+    size: 8Gi
+    storageClass: ""
+
+phpmyadmin:
+  image:
+    repository: phpmyadmin/phpmyadmin
+    tag: latest
+  service:
+    type: ClusterIP
+    port: 8088
+  uploadLimit: 500M
+
+gpt4all:
+  image:
+    repository: gpt4all
+    tag: latest
+
+weaviate:
+  image:
+    repository: weaviate
+    tag: latest
+
+prometheus:
+  image:
+    repository: prometheus
+    tag: latest
+
+grafana:
+  image:
+    repository: grafana
+    tag: latest
+  adminPassword: admin
+  allowSignUp: false
+  anonymous:
+    enabled: true
+    orgRole: Viewer
+    orgId: 1
+
+cadvisor:
+  image:
+    repository: gcr.io/cadvisor/cadvisor
+    tag: latest
+
+nodeExporter:
+  image:
+    repository: prom/node-exporter
+    tag: latest
+
+ingress:
+  enabled: true
+  className: "nginx"
+  host: "wiki-devops25.student.k8s.aet.cit.tum.de"
+  tls: true
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+
+resources: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
added two workflows to this repo:
1. create and push docker container to docker registry
2. deploy them to the AET rancher cluster using helm

for this I changes the docker-compose file and created a helm chart.
This implementation is currently untested, as I cannot run the Github actions locally and I need the access tokens for this repo. I don't know if the access tokens are already set, would have to try out after merging