### PR TITLE
Linting with spotbugs

### DIFF
--- a/.github/workflows/spotbugs_lint.yml
+++ b/.github/workflows/spotbugs_lint.yml
@@ -1,0 +1,28 @@
+name: Lint with SpotBugs
+
+on:
+  #pull_request:
+  #  branches: [ main ]
+  push:
+    branches:
+      - linting
+
+jobs:
+  spotbugs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Run SpotBugs
+        run: ./gradlew spotbugsMain spotbugsTest

--- a/.github/workflows/spotbugs_lint.yml
+++ b/.github/workflows/spotbugs_lint.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   spotbugs:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
 
     steps:
       - name: Checkout repository
@@ -22,7 +25,7 @@ jobs:
           java-version: '21'
 
       - name: Make gradlew executable
-        run: chmod +x ./backend/gradlew
+        run: chmod +x ./gradlew
 
       - name: Run SpotBugs
-        run: ./backend/gradlew spotbugsMain spotbugsTest
+        run: ./gradlew spotbugsMain spotbugsTest

--- a/.github/workflows/spotbugs_lint.yml
+++ b/.github/workflows/spotbugs_lint.yml
@@ -1,11 +1,8 @@
 name: Lint with SpotBugs
 
 on:
-  #pull_request:
-  #  branches: [ main ]
-  push:
-    branches:
-      - linting
+  pull_request:
+    branches: [ main ]
 
 jobs:
   spotbugs:

--- a/.github/workflows/spotbugs_lint.yml
+++ b/.github/workflows/spotbugs_lint.yml
@@ -22,7 +22,7 @@ jobs:
           java-version: '21'
 
       - name: Make gradlew executable
-        run: chmod +x ./gradlew
+        run: chmod +x ./backend/gradlew
 
       - name: Run SpotBugs
-        run: ./gradlew spotbugsMain spotbugsTest
+        run: ./backend/gradlew spotbugsMain spotbugsTest

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.4.5'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'com.github.spotbugs' version '6.0.5'
 }
 
 group = 'com.wiki'


### PR DESCRIPTION
closes #75

SpotBugs linting des backends für Pull Requests nach `main`

SpotBugs macht statische code analyse und kann z.B. Fehler wie ungenutzte attribute in einer Klasse finden. 